### PR TITLE
internal: switch to `tracing` from `log`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = ["xtask"]
 
 [dependencies]
 # Enable `log` feature to log assertion failures.
-log = { version="0.4", optional=true }
+tracing = { version="0.1", optional=true }
 
 [features]
 # Escalate assertion failure to panic even if `debug_assertions` are not set.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@
 ///
 /// If the condition is false:
 /// * panics if `force` feature or `debug_assertions` are enabled,
-/// * logs an error if `log` feature is enabled,
+/// * logs an error if the `tracing` feature is enabled,
 /// * evaluates to false.
 ///
 /// Accepts `format!` style arguments.
@@ -63,7 +63,7 @@ macro_rules! always {
             assert!(cond, $fmt $($arg)*);
         }
         if !cond {
-            $crate::__log_error!($fmt $($arg)*);
+            $crate::__tracing_error!($fmt $($arg)*);
         }
         cond
     }};
@@ -75,7 +75,7 @@ macro_rules! always {
 ///
 /// If the condition is true:
 /// * panics if `force` feature or `debug_assertions` are enabled,
-/// * logs an error if `log` feature is enabled,
+/// * logs an error if the `tracing` feature is enabled,
 /// * evaluates to true.
 ///
 /// Accepts `format!` style arguments.
@@ -94,7 +94,7 @@ macro_rules! never {
         if cfg!(debug_assertions) || $crate::__FORCE {
             unreachable!($fmt $(, $($arg)*)?);
         }
-        $crate::__log_error!($fmt $(, $($arg)*)?);
+        $crate::__tracing_error!($fmt $(, $($arg)*)?);
     }};
 
     ($cond:expr) => {{
@@ -108,14 +108,14 @@ macro_rules! never {
     }};
 }
 
-#[cfg(feature = "log")]
+#[cfg(feature = "tracing")]
 #[doc(hidden)]
-pub use log::error as __log_error;
+pub use tracing::error as __tracing_error;
 
-#[cfg(not(feature = "log"))]
+#[cfg(not(feature = "tracing"))]
 #[doc(hidden)]
 #[macro_export]
-macro_rules! __log_error {
+macro_rules! __tracing_error {
     ($($tt:tt)*) => {};
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -24,10 +24,10 @@ fn try_main() -> Result<()> {
     {
         let _s = section("TEST");
         for &release in &[None, Some("--release")] {
-            for &log in &[&[][..], &["--features", "log"]] {
+            for &tracing in &[&[][..], &["--features", "tracing"]] {
                 for &force in &[&[][..], &["--features", "force"]] {
                     cmd!(
-                        "cargo test {release...} {log...} {force...}
+                        "cargo test {release...} {tracing...} {force...}
                              --workspace -- --nocapture"
                     )
                     .run()?;


### PR DESCRIPTION
Necessary dependency of https://github.com/rust-lang/rust-analyzer/pull/16394.

(Note that this might be need to be bumped to a 0.2, since I replaced the feature with `tracing`. Let me know if you'd like to do that bump.)